### PR TITLE
Add Service Account authentication support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ env:
   CLIENT_ID: '${{ secrets.CLIENT_ID }}'
   CLIENT_SECRET: '${{ secrets.CLIENT_SECRET }}'
   REFRESH_TOKEN: '${{ secrets.REFRESH_TOKEN }}'
+  SERVICE_ACCOUNT_JSON: '${{ secrets.SERVICE_ACCOUNT_JSON }}'
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -31,4 +32,5 @@ jobs:
           -e CLIENT_ID \
           -e CLIENT_SECRET \
           -e REFRESH_TOKEN \
+          -e SERVICE_ACCOUNT_JSON \
           ${{env.APP_IMAGE}} composer ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,183 @@
-# Keboola Google API Client
+# Keboola Google Client Bundle
 
-Basic client for Google APIs  
+Keboola Google API Client with OAuth 2.0 and Service Account authentication support.
+
+## Installation
+
+```bash
+composer require keboola/google-client-bundle
+```
+
+## Usage
+
+This library supports two types of authentication:
+
+1. **OAuth 2.0** - for applications that need access to user data
+2. **Service Account** - for server-to-server communication without user intervention
+
+### OAuth 2.0 Authentication
+
+#### Classic approach
+
+```php
+use Keboola\Google\ClientBundle\Google\RestApi;
+
+$api = new RestApi($logger); // Optional logger parameter
+$api->setAppCredentials($clientId, $clientSecret);
+$api->setCredentials($accessToken, $refreshToken);
+
+// Get authorization URL
+$authUrl = $api->getAuthorizationUrl(
+    'http://localhost/callback',
+    'https://www.googleapis.com/auth/drive.readonly',
+    'force',
+    'offline'
+);
+
+// Authorize using code
+$tokens = $api->authorize($code, 'http://localhost/callback');
+
+// API calls
+$response = $api->request('/drive/v2/files');
+```
+
+#### New factory approach
+
+```php
+use Keboola\Google\ClientBundle\Google\RestApi;
+
+$api = RestApi::createWithOAuth(
+    $clientId,
+    $clientSecret,
+    $accessToken,
+    $refreshToken
+);
+
+// Usage same as above
+$response = $api->request('/drive/v2/files');
+```
+
+### Service Account Authentication
+
+```php
+use Keboola\Google\ClientBundle\Google\RestApi;
+
+// Service account JSON configuration (from Google Cloud Console)
+$serviceAccountConfig = [
+    'type' => 'service_account',
+    'project_id' => 'your-project-id',
+    'private_key_id' => 'key-id',
+    'private_key' => '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n',
+    'client_email' => 'your-service-account@your-project.iam.gserviceaccount.com',
+    'client_id' => '123456789',
+    'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+    'token_uri' => 'https://oauth2.googleapis.com/token',
+    'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+    'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project.iam.gserviceaccount.com'
+];
+
+// Scope definitions
+$scopes = [
+    'https://www.googleapis.com/auth/cloud-platform',
+    'https://www.googleapis.com/auth/drive.readonly'
+];
+
+// Create API client
+$api = RestApi::createWithServiceAccount(
+    $serviceAccountConfig,
+    $scopes
+);
+
+// API calls
+$response = $api->request('/drive/v2/files');
+```
+
+#### Loading Service Account from JSON file
+
+```php
+use Keboola\Google\ClientBundle\Google\RestApi;
+
+// Load from JSON file
+$serviceAccountConfig = json_decode(
+    file_get_contents('/path/to/service-account-key.json'),
+    true
+);
+
+$scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+
+$api = RestApi::createWithServiceAccount($serviceAccountConfig, $scopes);
+$response = $api->request('/your-api-endpoint');
+```
+
+## Differences between OAuth and Service Account
+
+| Property | OAuth 2.0 | Service Account |
+|----------|-----------|-----------------|
+| Authentication type | User-based | Server-to-server |
+| Refresh token | ✅ Yes | ❌ No (not needed) |
+| Authorization | Requires user consent | Automatic |
+| Usage | Access to user data | Access to application data |
+| Token expiration | Based on refresh token | Automatic renewal |
+
+## Advanced Usage
+
+### Retry and Backoff
+
+```php
+$api->setBackoffsCount(10); // Number of retries
+$api->setDelayFn(function($retries) {
+    return 1000 * pow(2, $retries); // Exponential backoff
+});
+```
+
+### Logging
+
+```php
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('google-api');
+$logger->pushHandler(new StreamHandler('php://stdout'));
+
+$api = RestApi::createWithServiceAccount(
+    $serviceAccountConfig,
+    $scopes,
+    $logger
+);
+```
+
+### Custom HTTP Options
+
+```php
+$response = $api->request('/endpoint', 'POST', [
+    'Content-Type' => 'application/json'
+], [
+    'json' => ['key' => 'value'],
+    'timeout' => 30
+]);
+```
+
+## Testing
+
+```bash
+# OAuth tests (require environment variables)
+export CLIENT_ID="your-client-id"
+export CLIENT_SECRET="your-client-secret"
+export REFRESH_TOKEN="your-refresh-token"
+
+# Service Account tests (optional)
+export SERVICE_ACCOUNT_JSON='{"type":"service_account","project_id":"your-project",...}'
+
+# Run tests
+composer tests
+```
+
+## Requirements
+
+- PHP ^7.1
+- guzzlehttp/guzzle ^6.0
+- google/auth ^1.26
 
 ## License
 
-MIT licensed, see [LICENSE](./LICENSE) file.
+MIT

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
 	"require": {
 		"php": "^8.1",
 		"guzzlehttp/guzzle": "^7.0",
-		"monolog/monolog": "^2.1"
+		"monolog/monolog": "^2.1",
+		"google/auth": "^1.26"
 	},
 	"require-dev": {
 		"keboola/coding-standard": "^15.0",
-		"phpstan/phpstan": "^1.4",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"phpstan/phpstan": "^2.1",
 		"phpunit/phpunit": "^9.5"
 	},
 	"minimum-stability": "stable",
@@ -28,7 +29,7 @@
 		}
 	},
 	"scripts": {
-		"tests": "phpunit",
+		"tests": "phpunit  --testdox",
 		"phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",
 		"phpcs": "phpcs -n --ignore=vendor --extensions=php .",
 		"phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - CLIENT_ID
       - CLIENT_SECRET
       - REFRESH_TOKEN
+      - SERVICE_ACCOUNT_JSON
 
   dev:
     build: .
@@ -21,3 +22,4 @@ services:
       - CLIENT_ID
       - CLIENT_SECRET
       - REFRESH_TOKEN
+      - SERVICE_ACCOUNT_JSON

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,205 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Binary operation "\+" between int\<1, max\> and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Binary operation "\." between ''Bearer '' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\Client\:\:options\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Cannot access offset ''access_token'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Cannot access offset ''expires_in'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Cannot call method fetchAuthToken\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:authorize\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:createWithServiceAccount\(\) has parameter \$scopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:createWithServiceAccount\(\) has parameter \$serviceAccountConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:decideRetry\(\) should return bool but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:getRefreshToken\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:getServiceAccountAccessToken\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:refreshToken\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:request\(\) has parameter \$addHeaders with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:request\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:request\(\) should return GuzzleHttp\\Psr7\\Response but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Parameter \#1 \$retries of method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:decideRetry\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Parameter \#1 \$retries of method Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:logRetryRequest\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Property Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:\$scopes \(array\<string\>\|null\) does not accept array\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Property Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:\$serviceAccountAccessToken \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Property Keboola\\Google\\ClientBundle\\Google\\RestApi\:\:\$serviceAccountConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Google/RestApi.php
+
+		-
+			message: '#^Cannot call method then\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Cannot use \+\+ on mixed\.$#'
+			identifier: preInc.type
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:__invoke\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:__invoke\(\) should return GuzzleHttp\\Promise\\PromiseInterface but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:doRetry\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:onFulfilled\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:onRejected\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Parameter \#1 \$request of method Keboola\\Google\\ClientBundle\\Guzzle\\RetryCallbackMiddleware\:\:doRetry\(\) expects Psr\\Http\\Message\\RequestInterface, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Guzzle/RetryCallbackMiddleware.php
+
+		-
+			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: tests/RestApiTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsString\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/RestApiTest.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Tests\\RestApiTest\:\:getServiceAccountConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/RestApiTest.php
+
+		-
+			message: '#^Method Keboola\\Google\\ClientBundle\\Tests\\RestApiTest\:\:getServiceAccountConfig\(\) should return array but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/RestApiTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\|ArrayAccess, mixed given\.$#'
+			identifier: argument.type
+			count: 6
+			path: tests/RestApiTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+    - phpstan-baseline.neon
 parameters:
-    checkMissingIterableValueType: false
+    level: max
     ignoreErrors:

--- a/tests/RestApiTest.php
+++ b/tests/RestApiTest.php
@@ -6,10 +6,12 @@ namespace Keboola\Google\ClientBundle\Tests;
 
 use Exception;
 use GuzzleHttp\Exception\ClientException;
+use Keboola\Google\ClientBundle\Exception\RestApiException;
 use Keboola\Google\ClientBundle\Google\RestApi;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SebastianBergmann\Timer\Timer;
 
 class RestApiTest extends TestCase
@@ -38,11 +40,49 @@ class RestApiTest extends TestCase
         $this->logger = new Logger('Google Rest API tests');
         $this->logger->pushHandler($this->testHandler);
 
-        return new RestApi(
+        $api = new RestApi($this->logger);
+        $api->setAppCredentials($this->clientId, $this->clientSecret);
+        $api->setCredentials('', $this->refreshToken);
+
+        return $api;
+    }
+
+    protected function initOAuthApi(): RestApi
+    {
+        $this->clientId = $this->getEnv('CLIENT_ID');
+        $this->clientSecret = $this->getEnv('CLIENT_SECRET');
+        $this->refreshToken = $this->getEnv('REFRESH_TOKEN');
+        $this->testHandler = new TestHandler();
+        $this->logger = new Logger('Google Rest API tests');
+        $this->logger->pushHandler($this->testHandler);
+
+        return RestApi::createWithOAuth(
             $this->clientId,
             $this->clientSecret,
             '',
             $this->refreshToken,
+            $this->logger,
+        );
+    }
+
+    protected function getServiceAccountConfig(): array
+    {
+        $serviceAccountJson = $this->getEnv('SERVICE_ACCOUNT_JSON');
+        return json_decode($serviceAccountJson, true);
+    }
+
+    protected function initServiceAccountApi(): RestApi
+    {
+        $this->testHandler = new TestHandler();
+        $this->logger = new Logger('Google Rest API tests');
+        $this->logger->pushHandler($this->testHandler);
+
+        $serviceAccountConfig = $this->getServiceAccountConfig();
+        $scopes = ['https://www.googleapis.com/auth/cloud-platform'];
+
+        return RestApi::createWithServiceAccount(
+            $serviceAccountConfig,
+            $scopes,
             $this->logger,
         );
     }
@@ -63,9 +103,158 @@ class RestApiTest extends TestCase
         $this->assertEquals($expectedUrl, $url);
     }
 
+    public function testOAuthCreateWithOAuth(): void
+    {
+        $restApi = $this->initOAuthApi();
+        $this->assertEquals(RestApi::AUTH_TYPE_OAUTH, $restApi->getAuthType());
+    }
+
+    public function testServiceAccountCreateWithServiceAccount(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $restApi = $this->initServiceAccountApi();
+        $this->assertEquals(RestApi::AUTH_TYPE_SERVICE_ACCOUNT, $restApi->getAuthType());
+    }
+
+    public function testServiceAccountGetRefreshTokenThrowsException(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $restApi = $this->initServiceAccountApi();
+
+        $this->expectException(RestApiException::class);
+        $this->expectExceptionMessage('Refresh token is not applicable for service account authentication');
+
+        $restApi->getRefreshToken();
+    }
+
+    public function testServiceAccountAuthentication(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $restApi = $this->initServiceAccountApi();
+        $accessToken = $restApi->getAccessToken();
+
+        $this->assertNotEmpty($accessToken);
+        $this->assertIsString($accessToken);
+    }
+
+    public function testServiceAccountRequest(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $restApi = $this->initServiceAccountApi();
+        $serviceAccountConfig = $this->getServiceAccountConfig();
+        $serviceAccountEmail = $serviceAccountConfig['client_email'];
+        $response = $restApi->request(sprintf(
+            '/oauth2/v3/tokeninfo?access_token=%s',
+            $restApi->getAccessToken(),
+        ));
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('azp', $body);
+        $this->assertArrayHasKey('aud', $body);
+        $this->assertArrayHasKey('access_type', $body);
+    }
+
+    public function testServiceAccountTokenCaching(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $restApi = $this->initServiceAccountApi();
+
+        // Get token twice - should be cached
+        $token1 = $restApi->getAccessToken();
+        $token2 = $restApi->getAccessToken();
+
+        $this->assertEquals($token1, $token2);
+        $this->assertNotEmpty($token1);
+    }
+
+    public function testServiceAccountInvalidConfiguration(): void
+    {
+        $this->testHandler = new TestHandler();
+        $this->logger = new Logger('Google Rest API tests');
+        $this->logger->pushHandler($this->testHandler);
+
+        $invalidConfig = [
+            'type' => 'service_account',
+            'project_id' => 'invalid-project',
+            // Missing required fields like private_key, client_email
+        ];
+
+        $this->expectException(RestApiException::class);
+        $this->expectExceptionMessage('Failed to initialize service account credentials');
+
+        RestApi::createWithServiceAccount(
+            $invalidConfig,
+            ['https://www.googleapis.com/auth/cloud-platform'],
+            $this->logger,
+        );
+    }
+
+    public function testServiceAccountRequestValidation(): void
+    {
+        // Create instance without proper configuration
+        $api = new RestApi(null);
+
+        // Manually set auth type to service account but don't initialize properly
+        $reflection = new ReflectionClass($api);
+        $authTypeProperty = $reflection->getProperty('authType');
+        $authTypeProperty->setAccessible(true);
+        $authTypeProperty->setValue($api, RestApi::AUTH_TYPE_SERVICE_ACCOUNT);
+
+        $this->expectException(RestApiException::class);
+        $this->expectExceptionMessage(
+            'Service account configuration and scopes must be set for service account authentication',
+        );
+
+        $api->request('/test-endpoint');
+    }
+
+    public function testServiceAccountWithoutRequiredScopes(): void
+    {
+        if (!$this->hasServiceAccountCredentials()) {
+            $this->markTestSkipped('Service account credentials not available');
+        }
+
+        $serviceAccountConfig = $this->getServiceAccountConfig();
+
+        $this->expectException(RestApiException::class);
+        $this->expectExceptionMessage('Service account configuration and scopes are required');
+
+        // Try to create with empty scopes
+        RestApi::createWithServiceAccount(
+            $serviceAccountConfig,
+            [], // Empty scopes
+            $this->logger,
+        );
+    }
+
     public function testRefreshToken(): void
     {
         $restApi = $this->initApi();
+        $response = $restApi->refreshToken();
+
+        $this->assertArrayHasKey('access_token', $response);
+        $this->assertNotEmpty($response['access_token']);
+    }
+
+    public function testOAuthRefreshToken(): void
+    {
+        $restApi = $this->initOAuthApi();
         $response = $restApi->refreshToken();
 
         $this->assertArrayHasKey('access_token', $response);
@@ -78,6 +267,17 @@ class RestApiTest extends TestCase
         $response = $restApi->request('/oauth2/v3/userinfo');
         $body = json_decode($response->getBody()->getContents(), true);
         self::assertIsArray($body);
+
+        $this->assertArrayHasKey('sub', $body);
+        $this->assertArrayHasKey('email', $body);
+        $this->assertArrayHasKey('name', $body);
+    }
+
+    public function testOAuthRequest(): void
+    {
+        $restApi = $this->initOAuthApi();
+        $response = $restApi->request('/oauth2/v3/userinfo');
+        $body = json_decode($response->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('sub', $body);
         $this->assertArrayHasKey('email', $body);
@@ -112,6 +312,7 @@ class RestApiTest extends TestCase
     public function testRetries(): void
     {
         $restApi = $this->initApi();
+        $restApi->setBackoffsCount(2);
         try {
             $restApi->request('/auth/invalid-scope');
         } catch (ClientException $e) {
@@ -131,7 +332,6 @@ class RestApiTest extends TestCase
                             'Host' => ['www.googleapis.com'],
                             'Accept' => ['application/json'],
                             'Authorization' => '*****',
-
                         ],
                         'method' => 'GET',
                         'body' => '',
@@ -139,13 +339,13 @@ class RestApiTest extends TestCase
                     'response' => [
                         'statusCode' => 404,
                         'reason' => 'Not Found',
-                        'body' => 'You are receiving this error either because your input OAuth2 scope name is ' .
-                            "invalid or it refers to a newer scope that is outside the domain of this legacy API.\n\n" .
-                            'This API was built at a time when the scope name format was not yet standardized. This ' .
-                            'is no longer the case and all valid scope names (both old and new) are catalogued at ' .
-                            'https://developers.google.com/identity/protocols/oauth2/scopes. Use that webpage to' .
-                            ' lookup (manually) the scope name associated with the API you are trying to call and use' .
-                            " it to craft your OAuth2 request.\n",
+                        'body' => 'You are receiving this error either because your input OAuth2 scope name is '
+                            . "invalid or it refers to a newer scope that is outside the domain of this legacy API.\n\n"
+                            . 'This API was built at a time when the scope name format was not yet standardized. '
+                            . 'This is no longer the case and all valid scope names (both old and new) are catalogued '
+                            . 'at https://developers.google.com/identity/protocols/oauth2/scopes. Use that webpage to'
+                            . ' lookup (manually) the scope name associated with the API you are trying to call and use'
+                            . " it to craft your OAuth2 request.\n",
                     ],
                 ],
                 $value['context'],
@@ -158,7 +358,7 @@ class RestApiTest extends TestCase
         $testHandler = new TestHandler();
         $logger = new Logger('Google Rest API tests');
         $logger->pushHandler($testHandler);
-        $api = new RestApi(
+        $api = RestApi::createWithOAuth(
             $this->getEnv('CLIENT_ID'),
             $this->getEnv('CLIENT_SECRET') . 'invalid',
             '',
@@ -188,5 +388,10 @@ class RestApiTest extends TestCase
         }
 
         return $value;
+    }
+
+    protected function hasServiceAccountCredentials(): bool
+    {
+        return getenv('SERVICE_ACCOUNT_JSON') !== false;
     }
 }


### PR DESCRIPTION
This PR extends the Google Client Bundle with Service Account authentication support, providing a more flexible authentication approach for server-to-server communication. 