### PR TITLE
Fix memory limit for phpstan

### DIFF
--- a/docker/php-prod.ini
+++ b/docker/php-prod.ini
@@ -13,6 +13,7 @@ session.sid_bits_per_character = 5
 short_open_tag = Off
 track_errors = Off
 variables_order = "GPCS"
+memory_limit = 256M
 
 ; Custom
 date.timezone = "UTC"


### PR DESCRIPTION
Phpstan padá na memory limitu - https://github.com/keboola/google-client-bundle/actions/runs/16605273328/job/46975368165

k ničemu jinému se tenhle php config nepoužívá, protože tohle je libka a docker image se používá jen pro testy